### PR TITLE
Add YAML/ENV based configuration

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,0 +1,7 @@
+# Example configuration for heychatgpt
+wake_word: "Computer"
+stt_backend: "porcupine"
+device_index: 0
+chatgpt_window_title_regex: "^ChatGPT$"
+audio_button_locator: "name:AudioButton"
+log_level: "INFO"

--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,74 @@
+import os
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Dict, Any
+
+
+ALLOWED_STT = {"porcupine", "sapi"}
+
+
+def _load_env_file(path: str = ".env") -> None:
+    if not os.path.exists(path):
+        return
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, value = line.split("=", 1)
+            os.environ.setdefault(key.strip(), value.strip())
+
+
+def _load_yaml(path: str) -> Dict[str, Any]:
+    data: Dict[str, Any] = {}
+    if not os.path.exists(path):
+        return data
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#") or ":" not in line:
+                continue
+            key, value = line.split(":", 1)
+            key = key.strip()
+            value = value.strip().strip("'\"")
+            if value.isdigit():
+                data[key] = int(value)
+            else:
+                data[key] = value
+    return data
+
+
+@dataclass
+class Settings:
+    wake_word: str = "Computer"
+    stt_backend: str = "porcupine"
+    device_index: int = 0
+    chatgpt_window_title_regex: str = "^ChatGPT$"
+    audio_button_locator: str = ""
+    log_level: str = "INFO"
+
+
+def _validate(settings: Settings) -> Settings:
+    if settings.stt_backend not in ALLOWED_STT:
+        raise ValueError(f"stt_backend must be one of {ALLOWED_STT}")
+    if not settings.audio_button_locator:
+        raise ValueError("audio_button_locator is required")
+    return settings
+
+
+@lru_cache()
+def get_settings(config_file: str | None = None) -> Settings:
+    _load_env_file()
+    cfg_path = config_file or os.environ.get("CONFIG_FILE", "config.yaml")
+    data = _load_yaml(cfg_path)
+
+    for field in Settings.__dataclass_fields__:
+        env_val = os.environ.get(field.upper())
+        if env_val is not None:
+            if field == "device_index":
+                data[field] = int(env_val)
+            else:
+                data[field] = env_val
+
+    settings = Settings(**data)
+    return _validate(settings)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,28 @@
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from config import get_settings  # type: ignore
+
+
+def test_env_overrides_yaml(tmp_path, monkeypatch):
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        """
+        wake_word: Computer
+        stt_backend: porcupine
+        device_index: 1
+        audio_button_locator: locator
+        """
+    )
+    monkeypatch.setenv("CONFIG_FILE", str(cfg))
+    monkeypatch.setenv("WAKE_WORD", "Jarvis")
+
+    get_settings.cache_clear()
+    settings = get_settings()
+
+    assert settings.wake_word == "Jarvis"
+    assert settings.device_index == 1
+    assert settings.log_level == "INFO"


### PR DESCRIPTION
## Summary
- add `config` module using dataclasses to load settings from YAML and environment
- support optional `.env` file, environment variable overrides and basic validation
- include example `config.example.yaml` and tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6899b9a20afc832bb9f7732fd070bdae